### PR TITLE
Update to firehose-to-syslog v0.0.2

### DIFF
--- a/logsearch-for-cloudfoundry-boshrelease/packages/firehose-to-syslog/packaging
+++ b/logsearch-for-cloudfoundry-boshrelease/packages/firehose-to-syslog/packaging
@@ -12,12 +12,6 @@ mkdir -p $BOSH_INSTALL_TARGET/bin
 
 cp -a $(basename $REPO_NAME)/ $REPO_DIR
 
-#FIXME: I'm sure we shouldn't have to manually fetch this dependancy - shouldn't it already be included in Godeps/ ?
-GOLANG_X_NET_PATH=$REPO_DIR/Godeps/_workspace/src/golang.org/x/net
-mkdir -p $GOLANG_X_NET_PATH
-curl -L https://github.com/golang/net/archive/7dbad50ab5b31073856416cdcfeb2796d682f844.tar.gz | tar xz --strip-components=1 -C $GOLANG_X_NET_PATH
-#END:FIXME
-
 export GOROOT=$(readlink -nf /var/vcap/packages/golang1.4)
 export GOPATH=$BOSH_INSTALL_TARGET:${REPO_DIR}/Godeps/_workspace
 export PATH=$GOROOT/bin:$PATH


### PR DESCRIPTION
Also, removes the (now) unnecessary fetching of the $REPO_DIR/Godeps/_workspace/src/golang.org/x/net dependancy during compilation