### PR TITLE
Decorate doppler logs with App name / space / org

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,16 @@ This has been tested on cf-release v205 and logsearch-boshrelease v19.
                  firehose-user: admin
                  firehose-password: admin
                  syslog-server: "10.244.10.6:514"
-   
+  
+   * Colocate the `cf_app_details_cache` template on all your log_parser jobs: 
+
+           jobs:
+             - name: log_parser
+               templates: 
+               - name: log_parser
+               - { name: cf_app_details_cache, release: logsearch-for-cloudfoundry }
+               ...snip...
+
    * Include `logsearch-for-cloudfoundry/logstash-filters-default.conf` log_parsing rules
            properties:
              logstash_parser:

--- a/logsearch-for-cloudfoundry-boshrelease/jobs/cf_app_details_cache/monit
+++ b/logsearch-for-cloudfoundry-boshrelease/jobs/cf_app_details_cache/monit
@@ -1,0 +1,5 @@
+check process cf_app_details_cache
+  with pidfile /var/vcap/sys/run/cf_app_details_cache/cf_app_details_cache.pid
+  start program "/var/vcap/jobs/cf_app_details_cache/bin/monit_debugger cf_app_details_cache_ctl '/var/vcap/jobs/cf_app_details_cache/bin/cf_app_details_cache_ctl start'"
+  stop program "/var/vcap/jobs/cf_app_details_cache/bin/monit_debugger cf_app_details_cache_ctl '/var/vcap/jobs/cf_app_details_cache/bin/cf_app_details_cache_ctl stop'"
+  group vcap

--- a/logsearch-for-cloudfoundry-boshrelease/jobs/cf_app_details_cache/spec
+++ b/logsearch-for-cloudfoundry-boshrelease/jobs/cf_app_details_cache/spec
@@ -1,0 +1,10 @@
+---
+name: cf_app_details_cache
+packages: []
+templates:
+  bin/cf_app_details_cache_ctl: bin/cf_app_details_cache_ctl
+  bin/monit_debugger: bin/monit_debugger
+  data/properties.sh.erb: data/properties.sh
+  helpers/ctl_setup.sh: helpers/ctl_setup.sh
+  helpers/ctl_utils.sh: helpers/ctl_utils.sh
+properties: {}

--- a/logsearch-for-cloudfoundry-boshrelease/jobs/cf_app_details_cache/templates/bin/cf_app_details_cache_ctl
+++ b/logsearch-for-cloudfoundry-boshrelease/jobs/cf_app_details_cache/templates/bin/cf_app_details_cache_ctl
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+# Setup env vars and folders for the webapp_ctl script
+source /var/vcap/jobs/cf_app_details_cache/helpers/ctl_setup.sh 'cf_app_details_cache'
+
+mkdir -p /var/vcap/store/cf_app_details_cache
+touch /var/vcap/store/cf_app_details_cache/cf_app_space_org_dictionary.yml
+
+case $1 in
+
+  start)
+    pid_guard $PIDFILE $JOB_NAME
+
+    # store pid in $PIDFILE
+    echo $$ > $PIDFILE
+
+    while true; do
+      echo "Updating /var/vcap/store/cf_app_details_cache/cf_app_space_org_dictionary.yml" >> $LOG_DIR/$JOB_NAME.stdout.log
+      #TODO: Pull live data...
+      sleep 300
+    done
+    ;;
+
+  stop)
+    kill_and_wait $PIDFILE
+
+    ;;
+  *)
+    echo "Usage: cf_app_details_cache_ctl {start|stop}"
+
+    ;;
+
+esac
+exit 0

--- a/logsearch-for-cloudfoundry-boshrelease/jobs/cf_app_details_cache/templates/bin/monit_debugger
+++ b/logsearch-for-cloudfoundry-boshrelease/jobs/cf_app_details_cache/templates/bin/monit_debugger
@@ -1,0 +1,13 @@
+#!/bin/sh
+# USAGE monit_debugger <label> command to run
+mkdir -p /var/vcap/sys/log/monit
+{
+  echo "MONIT-DEBUG date"
+  date
+  echo "MONIT-DEBUG env"
+  env
+  echo "MONIT-DEBUG $@"
+  $2 $3 $4 $5 $6 $7
+  R=$?
+  echo "MONIT-DEBUG exit code $R"
+} >/var/vcap/sys/log/monit/monit_debugger.$1.log 2>&1

--- a/logsearch-for-cloudfoundry-boshrelease/jobs/cf_app_details_cache/templates/data/properties.sh.erb
+++ b/logsearch-for-cloudfoundry-boshrelease/jobs/cf_app_details_cache/templates/data/properties.sh.erb
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# job template binding variables
+
+# job name & index of this VM within cluster
+# e.g. JOB_NAME=redis, JOB_INDEX=0
+export NAME='<%= name %>'
+export JOB_INDEX=<%= index %>
+# full job name, like redis/0 or webapp/3
+export JOB_FULL="$NAME/$JOB_INDEX"

--- a/logsearch-for-cloudfoundry-boshrelease/jobs/cf_app_details_cache/templates/helpers/ctl_setup.sh
+++ b/logsearch-for-cloudfoundry-boshrelease/jobs/cf_app_details_cache/templates/helpers/ctl_setup.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# Setup env vars and folders for the ctl script
+# This helps keep the ctl script as readable
+# as possible
+
+# Usage options:
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh JOB_NAME OUTPUT_LABEL
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar foobar
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar nginx
+
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+JOB_NAME=$1
+output_label=${2:-${JOB_NAME}}
+
+export JOB_DIR=/var/vcap/jobs/$JOB_NAME
+chmod 755 $JOB_DIR # to access file via symlink
+
+# Load some bosh deployment properties into env vars
+# Try to put all ERb into data/properties.sh.erb
+# incl $NAME, $JOB_INDEX, $WEBAPP_DIR
+source $JOB_DIR/data/properties.sh
+
+source $JOB_DIR/helpers/ctl_utils.sh
+redirect_output ${output_label}
+
+export HOME=${HOME:-/home/vcap}
+
+# Add all packages' /bin & /sbin into $PATH
+for package_bin_dir in $(ls -d /var/vcap/packages/*/*bin)
+do
+  export PATH=${package_bin_dir}:$PATH
+done
+
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty
+for package_bin_dir in $(ls -d /var/vcap/packages/*/lib)
+do
+  export LD_LIBRARY_PATH=${package_bin_dir}:$LD_LIBRARY_PATH
+done
+
+# Setup log, run and tmp folders
+
+export RUN_DIR=/var/vcap/sys/run/$JOB_NAME
+export LOG_DIR=/var/vcap/sys/log/$JOB_NAME
+export TMP_DIR=/var/vcap/sys/tmp/$JOB_NAME
+export STORE_DIR=/var/vcap/store/$JOB_NAME
+for dir in $RUN_DIR $LOG_DIR $TMP_DIR $STORE_DIR
+do
+  mkdir -p ${dir}
+  chown vcap:vcap ${dir}
+  chmod 775 ${dir}
+done
+export TMPDIR=$TMP_DIR
+
+export C_INCLUDE_PATH=/var/vcap/packages/mysqlclient/include/mysql:/var/vcap/packages/sqlite/include:/var/vcap/packages/libpq/include
+export LIBRARY_PATH=/var/vcap/packages/mysqlclient/lib/mysql:/var/vcap/packages/sqlite/lib:/var/vcap/packages/libpq/lib
+
+# consistent place for vendoring python libraries within package
+if [[ -d ${WEBAPP_DIR:-/xxxx} ]]
+then
+  export PYTHONPATH=$WEBAPP_DIR/vendor/lib/python
+fi
+
+if [[ -d /var/vcap/packages/java7 ]]
+then
+  export JAVA_HOME="/var/vcap/packages/java7"
+fi
+
+# setup CLASSPATH for all jars/ folders within packages
+export CLASSPATH=${CLASSPATH:-''} # default to empty
+for java_jar in $(ls -d /var/vcap/packages/*/*/*.jar)
+do
+  export CLASSPATH=${java_jar}:$CLASSPATH
+done
+
+PIDFILE=$RUN_DIR/$output_label.pid
+
+echo '$PATH' $PATH

--- a/logsearch-for-cloudfoundry-boshrelease/jobs/cf_app_details_cache/templates/helpers/ctl_utils.sh
+++ b/logsearch-for-cloudfoundry-boshrelease/jobs/cf_app_details_cache/templates/helpers/ctl_utils.sh
@@ -1,0 +1,156 @@
+# Helper functions used by ctl scripts
+
+# links a job file (probably a config file) into a package
+# Example usage:
+# link_job_file_to_package config/redis.yml [config/redis.yml]
+# link_job_file_to_package config/wp-config.php wp-config.php
+link_job_file_to_package() {
+  source_job_file=$1
+  target_package_file=${2:-$source_job_file}
+  full_package_file=$WEBAPP_DIR/${target_package_file}
+
+  link_job_file ${source_job_file} ${full_package_file}
+}
+
+# links a job file (probably a config file) somewhere
+# Example usage:
+# link_job_file config/bashrc /home/vcap/.bashrc
+link_job_file() {
+  source_job_file=$1
+  target_file=$2
+  full_job_file=$JOB_DIR/${source_job_file}
+
+  echo link_job_file ${full_job_file} ${target_file}
+  if [[ ! -f ${full_job_file} ]]
+  then
+    echo "file to link ${full_job_file} does not exist"
+  else
+    # Create/recreate the symlink to current job file
+    # If another process is using the file, it won't be
+    # deleted, so don't attempt to create the symlink
+    mkdir -p $(dirname ${target_file})
+    ln -nfs ${full_job_file} ${target_file}
+  fi
+}
+
+# If loaded within monit ctl scripts then pipe output
+# If loaded from 'source ../utils.sh' then normal STDOUT
+redirect_output() {
+  SCRIPT=$1
+  mkdir -p /var/vcap/sys/log/monit
+  exec 1>> /var/vcap/sys/log/monit/$SCRIPT.log
+  exec 2>> /var/vcap/sys/log/monit/$SCRIPT.err.log
+}
+
+pid_guard() {
+  pidfile=$1
+  name=$2
+
+  if [ -f "$pidfile" ]; then
+    pid=$(head -1 "$pidfile")
+
+    if [ -n "$pid" ] && [ -e /proc/$pid ]; then
+      echo "$name is already running, please stop it first"
+      exit 1
+    fi
+
+    echo "Removing stale pidfile..."
+    rm $pidfile
+  fi
+}
+
+wait_pid() {
+  pid=$1
+  try_kill=$2
+  timeout=${3:-0}
+  force=${4:-0}
+  countdown=$(( $timeout * 10 ))
+
+  echo wait_pid $pid $try_kill $timeout $force $countdown
+  if [ -e /proc/$pid ]; then
+    if [ "$try_kill" = "1" ]; then
+      echo "Killing $pidfile: $pid "
+      kill $pid
+    fi
+    while [ -e /proc/$pid ]; do
+      sleep 0.1
+      [ "$countdown" != '0' -a $(( $countdown % 10 )) = '0' ] && echo -n .
+      if [ $timeout -gt 0 ]; then
+        if [ $countdown -eq 0 ]; then
+          if [ "$force" = "1" ]; then
+            echo -ne "\nKill timed out, using kill -9 on $pid... "
+            kill -9 $pid
+            sleep 0.5
+          fi
+          break
+        else
+          countdown=$(( $countdown - 1 ))
+        fi
+      fi
+    done
+    if [ -e /proc/$pid ]; then
+      echo "Timed Out"
+    else
+      echo "Stopped"
+    fi
+  else
+    echo "Process $pid is not running"
+    echo "Attempting to kill pid anyway..."
+    kill $pid
+  fi
+}
+
+wait_pidfile() {
+  pidfile=$1
+  try_kill=$2
+  timeout=${3:-0}
+  force=${4:-0}
+  countdown=$(( $timeout * 10 ))
+
+  if [ -f "$pidfile" ]; then
+    pid=$(head -1 "$pidfile")
+    if [ -z "$pid" ]; then
+      echo "Unable to get pid from $pidfile"
+      exit 1
+    fi
+
+    wait_pid $pid $try_kill $timeout $force
+
+    rm -f $pidfile
+  else
+    echo "Pidfile $pidfile doesn't exist"
+  fi
+}
+
+kill_and_wait() {
+  pidfile=$1
+  # Monit default timeout for start/stop is 30s
+  # Append 'with timeout {n} seconds' to monit start/stop program configs
+  timeout=${2:-25}
+  force=${3:-1}
+  if [[ -f ${pidfile} ]]
+  then
+    wait_pidfile $pidfile 1 $timeout $force
+  else
+    # TODO assume $1 is something to grep from 'ps ax'
+    pid="$(ps auwwx | grep "$1" | awk '{print $2}')"
+    wait_pid $pid 1 $timeout $force
+  fi
+}
+
+check_nfs_mount() {
+  opts=$1
+  exports=$2
+  mount_point=$3
+
+  if grep -qs $mount_point /proc/mounts; then
+    echo "Found NFS mount $mount_point"
+  else
+    echo "Mounting NFS..."
+    mount $opts $exports $mount_point
+    if [ $? != 0 ]; then
+      echo "Cannot mount NFS from $exports to $mount_point, exiting..."
+      exit 1
+    fi
+  fi
+}

--- a/src/logstash-filters/snippets/doppler.conf
+++ b/src/logstash-filters/snippets/doppler.conf
@@ -59,9 +59,9 @@ if "_jsonparsefailure" in [tags] {
         dictionary => [ 
             'ec2d33f6-fd1c-49a5-9a90-031454d1f1ac', '{"cf_app_id":"ec2d33f6-fd1c-49a5-9a90-031454d1f1ac","cf_app_name":"myappname","cf_space_id":"ec2d33f6-fd1c-49a5-9a90-03145444444","cf_space_name":"myspacename","cf_org_id":"ec2d33f6-fd1c-49a5-9a90-031454d555555","cf_org_name":"myorgname"}',
             'afc7d161-b5d5-44f2-a2c8-63870ff8f2db', '{"cf_app_id":"afc7d161-b5d5-44f2-a2c8-63870ff8f2db","cf_app_name":"goexample","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
+            '4616c1e3-faa9-4a33-a1c2-2ddf493ca606', '{"cf_app_id":"4616c1e3-faa9-4a33-a1c2-2ddf493ca606","cf_app_name":"goexample","cf_space_id":"397a7397-0fff-4f7b-a7a4-a320f29e403d","cf_space_name":"production","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
             'abfc9a95-d20c-44bb-9771-4aba27856843', '{"cf_app_id":"abfc9a95-d20c-44bb-9771-4aba27856843","cf_app_name":"cf-env","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
             'e6f78bd9-ca15-42d3-894e-d2b8b06e5e83', '{"cf_app_id":"e6f78bd9-ca15-42d3-894e-d2b8b06e5e83","cf_app_name":"discourse","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}'
-        
         ]
         fallback => '{"cf_app_id_unknown":"00000000-0000-0000-0000-000000000000","cf_app_name":"UNKNOWN","cf_space_id":"00000000-0000-0000-0000-000000000000","cf_space_name":"UNKNOWN","cf_org_id":"00000000-0000-0000-0000-000000000000","cf_org_name":"UNKNOWN"}'
         field => "cf_app_id"

--- a/src/logstash-filters/snippets/doppler.conf
+++ b/src/logstash-filters/snippets/doppler.conf
@@ -55,18 +55,13 @@ if "_jsonparsefailure" in [tags] {
 
     #EXPERIMENTAL: Decorate log event with app name / space / org metadata
     translate {
-        #Lookup using: cf curl "/v2/apps/$APP_UUID?inline-relations-depth=2" | jq --compact-output '. | { cf_app_id: .metadata.guid, cf_app_name: .entity.name , cf_space_id: .entity.space.metadata.guid , cf_space_name: .entity.space.entity.name , cf_org_id: .entity.space.entity.organization.metadata.guid , cf_org_name: .entity.space.entity.organization.entity.name }'
-        dictionary => [ 
-            'ec2d33f6-fd1c-49a5-9a90-031454d1f1ac', '{"cf_app_id":"ec2d33f6-fd1c-49a5-9a90-031454d1f1ac","cf_app_name":"myappname","cf_space_id":"ec2d33f6-fd1c-49a5-9a90-03145444444","cf_space_name":"myspacename","cf_org_id":"ec2d33f6-fd1c-49a5-9a90-031454d555555","cf_org_name":"myorgname"}',
-            'afc7d161-b5d5-44f2-a2c8-63870ff8f2db', '{"cf_app_id":"afc7d161-b5d5-44f2-a2c8-63870ff8f2db","cf_app_name":"goexample","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
-            '4616c1e3-faa9-4a33-a1c2-2ddf493ca606', '{"cf_app_id":"4616c1e3-faa9-4a33-a1c2-2ddf493ca606","cf_app_name":"goexample","cf_space_id":"397a7397-0fff-4f7b-a7a4-a320f29e403d","cf_space_name":"production","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
-            'abfc9a95-d20c-44bb-9771-4aba27856843', '{"cf_app_id":"abfc9a95-d20c-44bb-9771-4aba27856843","cf_app_name":"cf-env","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
-            'e6f78bd9-ca15-42d3-894e-d2b8b06e5e83', '{"cf_app_id":"e6f78bd9-ca15-42d3-894e-d2b8b06e5e83","cf_app_name":"discourse","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}'
-        ]
-        fallback => '{"cf_app_id_unknown":"00000000-0000-0000-0000-000000000000","cf_app_name":"UNKNOWN","cf_space_id":"00000000-0000-0000-0000-000000000000","cf_space_name":"UNKNOWN","cf_org_id":"00000000-0000-0000-0000-000000000000","cf_org_name":"UNKNOWN"}'
         field => "cf_app_id"
         destination => "cf_app_metadata_raw"
+
+        dictionary_path => "/var/vcap/store/cf_app_details_cache/cf_app_space_org_dictionary.yml"
+        fallback => '{"cf_app_id_unknown":"00000000-0000-0000-0000-000000000000","cf_app_name":"UNKNOWN","cf_space_id":"00000000-0000-0000-0000-000000000000","cf_space_name":"UNKNOWN","cf_org_id":"00000000-0000-0000-0000-000000000000","cf_org_name":"UNKNOWN"}'
     }
+    
     json {
         source => 'cf_app_metadata_raw'
         remove_field => [ "cf_app_metadata_raw", "cf_app_id_unknown" ]

--- a/src/logstash-filters/snippets/doppler.conf
+++ b/src/logstash-filters/snippets/doppler.conf
@@ -53,6 +53,25 @@ if "_jsonparsefailure" in [tags] {
         }
     }
 
+    #EXPERIMENTAL: Decorate log event with app name / space / org metadata
+    translate {
+        #Lookup using: cf curl "/v2/apps/$APP_UUID?inline-relations-depth=2" | jq --compact-output '. | { cf_app_id: .metadata.guid, cf_app_name: .entity.name , cf_space_id: .entity.space.metadata.guid , cf_space_name: .entity.space.entity.name , cf_org_id: .entity.space.entity.organization.metadata.guid , cf_org_name: .entity.space.entity.organization.entity.name }'
+        dictionary => [ 
+            'ec2d33f6-fd1c-49a5-9a90-031454d1f1ac', '{"cf_app_id":"ec2d33f6-fd1c-49a5-9a90-031454d1f1ac","cf_app_name":"myappname","cf_space_id":"ec2d33f6-fd1c-49a5-9a90-03145444444","cf_space_name":"myspacename","cf_org_id":"ec2d33f6-fd1c-49a5-9a90-031454d555555","cf_org_name":"myorgname"}',
+            'afc7d161-b5d5-44f2-a2c8-63870ff8f2db', '{"cf_app_id":"afc7d161-b5d5-44f2-a2c8-63870ff8f2db","cf_app_name":"goexample","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
+            'abfc9a95-d20c-44bb-9771-4aba27856843', '{"cf_app_id":"abfc9a95-d20c-44bb-9771-4aba27856843","cf_app_name":"cf-env","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
+            'e6f78bd9-ca15-42d3-894e-d2b8b06e5e83', '{"cf_app_id":"e6f78bd9-ca15-42d3-894e-d2b8b06e5e83","cf_app_name":"discourse","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}'
+        
+        ]
+        fallback => '{"cf_app_id_unknown":"00000000-0000-0000-0000-000000000000","cf_app_name":"UNKNOWN","cf_space_id":"00000000-0000-0000-0000-000000000000","cf_space_name":"UNKNOWN","cf_org_id":"00000000-0000-0000-0000-000000000000","cf_org_name":"UNKNOWN"}'
+        field => "cf_app_id"
+        destination => "cf_app_metadata_raw"
+    }
+    json {
+        source => 'cf_app_metadata_raw'
+        remove_field => [ "cf_app_metadata_raw", "cf_app_id_unknown" ]
+    }
+
     #Ensure that we always have an event_type, in prep for adding metrics
     if ![event_type] {
         mutate {

--- a/target/logstash-filters-default.conf
+++ b/target/logstash-filters-default.conf
@@ -59,18 +59,13 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
   
       #EXPERIMENTAL: Decorate log event with app name / space / org metadata
       translate {
-          #Lookup using: cf curl "/v2/apps/$APP_UUID?inline-relations-depth=2" | jq --compact-output '. | { cf_app_id: .metadata.guid, cf_app_name: .entity.name , cf_space_id: .entity.space.metadata.guid , cf_space_name: .entity.space.entity.name , cf_org_id: .entity.space.entity.organization.metadata.guid , cf_org_name: .entity.space.entity.organization.entity.name }'
-          dictionary => [ 
-              'ec2d33f6-fd1c-49a5-9a90-031454d1f1ac', '{"cf_app_id":"ec2d33f6-fd1c-49a5-9a90-031454d1f1ac","cf_app_name":"myappname","cf_space_id":"ec2d33f6-fd1c-49a5-9a90-03145444444","cf_space_name":"myspacename","cf_org_id":"ec2d33f6-fd1c-49a5-9a90-031454d555555","cf_org_name":"myorgname"}',
-              'afc7d161-b5d5-44f2-a2c8-63870ff8f2db', '{"cf_app_id":"afc7d161-b5d5-44f2-a2c8-63870ff8f2db","cf_app_name":"goexample","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
-              '4616c1e3-faa9-4a33-a1c2-2ddf493ca606', '{"cf_app_id":"4616c1e3-faa9-4a33-a1c2-2ddf493ca606","cf_app_name":"goexample","cf_space_id":"397a7397-0fff-4f7b-a7a4-a320f29e403d","cf_space_name":"production","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
-              'abfc9a95-d20c-44bb-9771-4aba27856843', '{"cf_app_id":"abfc9a95-d20c-44bb-9771-4aba27856843","cf_app_name":"cf-env","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
-              'e6f78bd9-ca15-42d3-894e-d2b8b06e5e83', '{"cf_app_id":"e6f78bd9-ca15-42d3-894e-d2b8b06e5e83","cf_app_name":"discourse","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}'
-          ]
-          fallback => '{"cf_app_id_unknown":"00000000-0000-0000-0000-000000000000","cf_app_name":"UNKNOWN","cf_space_id":"00000000-0000-0000-0000-000000000000","cf_space_name":"UNKNOWN","cf_org_id":"00000000-0000-0000-0000-000000000000","cf_org_name":"UNKNOWN"}'
           field => "cf_app_id"
           destination => "cf_app_metadata_raw"
+  
+          dictionary_path => "/var/vcap/store/cf_app_details_cache/cf_app_space_org_dictionary.yml"
+          fallback => '{"cf_app_id_unknown":"00000000-0000-0000-0000-000000000000","cf_app_name":"UNKNOWN","cf_space_id":"00000000-0000-0000-0000-000000000000","cf_space_name":"UNKNOWN","cf_org_id":"00000000-0000-0000-0000-000000000000","cf_org_name":"UNKNOWN"}'
       }
+      
       json {
           source => 'cf_app_metadata_raw'
           remove_field => [ "cf_app_metadata_raw", "cf_app_id_unknown" ]

--- a/target/logstash-filters-default.conf
+++ b/target/logstash-filters-default.conf
@@ -63,9 +63,9 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
           dictionary => [ 
               'ec2d33f6-fd1c-49a5-9a90-031454d1f1ac', '{"cf_app_id":"ec2d33f6-fd1c-49a5-9a90-031454d1f1ac","cf_app_name":"myappname","cf_space_id":"ec2d33f6-fd1c-49a5-9a90-03145444444","cf_space_name":"myspacename","cf_org_id":"ec2d33f6-fd1c-49a5-9a90-031454d555555","cf_org_name":"myorgname"}',
               'afc7d161-b5d5-44f2-a2c8-63870ff8f2db', '{"cf_app_id":"afc7d161-b5d5-44f2-a2c8-63870ff8f2db","cf_app_name":"goexample","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
+              '4616c1e3-faa9-4a33-a1c2-2ddf493ca606', '{"cf_app_id":"4616c1e3-faa9-4a33-a1c2-2ddf493ca606","cf_app_name":"goexample","cf_space_id":"397a7397-0fff-4f7b-a7a4-a320f29e403d","cf_space_name":"production","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
               'abfc9a95-d20c-44bb-9771-4aba27856843', '{"cf_app_id":"abfc9a95-d20c-44bb-9771-4aba27856843","cf_app_name":"cf-env","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
               'e6f78bd9-ca15-42d3-894e-d2b8b06e5e83', '{"cf_app_id":"e6f78bd9-ca15-42d3-894e-d2b8b06e5e83","cf_app_name":"discourse","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}'
-          
           ]
           fallback => '{"cf_app_id_unknown":"00000000-0000-0000-0000-000000000000","cf_app_name":"UNKNOWN","cf_space_id":"00000000-0000-0000-0000-000000000000","cf_space_name":"UNKNOWN","cf_org_id":"00000000-0000-0000-0000-000000000000","cf_org_name":"UNKNOWN"}'
           field => "cf_app_id"

--- a/target/logstash-filters-default.conf
+++ b/target/logstash-filters-default.conf
@@ -57,6 +57,25 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
           }
       }
   
+      #EXPERIMENTAL: Decorate log event with app name / space / org metadata
+      translate {
+          #Lookup using: cf curl "/v2/apps/$APP_UUID?inline-relations-depth=2" | jq --compact-output '. | { cf_app_id: .metadata.guid, cf_app_name: .entity.name , cf_space_id: .entity.space.metadata.guid , cf_space_name: .entity.space.entity.name , cf_org_id: .entity.space.entity.organization.metadata.guid , cf_org_name: .entity.space.entity.organization.entity.name }'
+          dictionary => [ 
+              'ec2d33f6-fd1c-49a5-9a90-031454d1f1ac', '{"cf_app_id":"ec2d33f6-fd1c-49a5-9a90-031454d1f1ac","cf_app_name":"myappname","cf_space_id":"ec2d33f6-fd1c-49a5-9a90-03145444444","cf_space_name":"myspacename","cf_org_id":"ec2d33f6-fd1c-49a5-9a90-031454d555555","cf_org_name":"myorgname"}',
+              'afc7d161-b5d5-44f2-a2c8-63870ff8f2db', '{"cf_app_id":"afc7d161-b5d5-44f2-a2c8-63870ff8f2db","cf_app_name":"goexample","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
+              'abfc9a95-d20c-44bb-9771-4aba27856843', '{"cf_app_id":"abfc9a95-d20c-44bb-9771-4aba27856843","cf_app_name":"cf-env","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
+              'e6f78bd9-ca15-42d3-894e-d2b8b06e5e83', '{"cf_app_id":"e6f78bd9-ca15-42d3-894e-d2b8b06e5e83","cf_app_name":"discourse","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}'
+          
+          ]
+          fallback => '{"cf_app_id_unknown":"00000000-0000-0000-0000-000000000000","cf_app_name":"UNKNOWN","cf_space_id":"00000000-0000-0000-0000-000000000000","cf_space_name":"UNKNOWN","cf_org_id":"00000000-0000-0000-0000-000000000000","cf_org_name":"UNKNOWN"}'
+          field => "cf_app_id"
+          destination => "cf_app_metadata_raw"
+      }
+      json {
+          source => 'cf_app_metadata_raw'
+          remove_field => [ "cf_app_metadata_raw", "cf_app_id_unknown" ]
+      }
+  
       #Ensure that we always have an event_type, in prep for adding metrics
       if ![event_type] {
           mutate {

--- a/test/logstash-filters/snippets/doppler-spec.rb
+++ b/test/logstash-filters/snippets/doppler-spec.rb
@@ -1,13 +1,33 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/filters/grok"
+require 'tempfile'
+
+#Lookup using: cf curl "/v2/apps/$APP_UUID?inline-relations-depth=2" | jq --compact-output '. | { cf_app_id: .metadata.guid, cf_app_name: .entity.name , cf_space_id: .entity.space.metadata.guid , cf_space_name: .entity.space.entity.name , cf_org_id: .entity.space.entity.organization.metadata.guid , cf_org_name: .entity.space.entity.organization.entity.name }'
+DICTIONARY = <<EOD
+'9af4f832-32cf-47c1-bce8-f2e852ea0730': '{"cf_app_id":"9af4f832-32cf-47c1-bce8-f2e852ea0730","cf_app_name":"app-logs","cf_space_id":"5c98b860-f5d2-444c-b923-d91b277b5269","cf_space_name":"production","cf_org_id":"8005f45b-76d9-4038-8ca1-9e0a85ed5be0","cf_org_name":"system"}'
+'54967f0c-5069-4428-83de-84f86c1286e2': '{"cf_app_id":"54967f0c-5069-4428-83de-84f86c1286e2","cf_app_name":"devApp1","cf_space_id":"a871a722-cad2-4d46-8061-2c9b728b7d8f","cf_space_name":"development","cf_org_id":"8005f45b-76d9-4038-8ca1-9e0a85ed5be0","cf_org_name":"system"}'
+'2769b9da-5ad7-4bbc-a337-d9fc14ed355e': '{"cf_app_id":"2769b9da-5ad7-4bbc-a337-d9fc14ed355e","cf_app_name":"testApp1","cf_space_id":"182d42fe-eebf-4826-9127-38a49fac8e91","cf_space_name":"test","cf_org_id":"8005f45b-76d9-4038-8ca1-9e0a85ed5be0","cf_org_name":"system"}'
+'d7d702c9-7863-4d16-a375-be7cd960022d': '{"cf_app_id":"d7d702c9-7863-4d16-a375-be7cd960022d","cf_app_name":"prodApp1","cf_space_id":"5c98b860-f5d2-444c-b923-d91b277b5269","cf_space_name":"production","cf_org_id":"8005f45b-76d9-4038-8ca1-9e0a85ed5be0","cf_org_name":"system"}'
+'ec2d33f6-fd1c-49a5-9a90-031454d1f1ac': '{"cf_app_id":"ec2d33f6-fd1c-49a5-9a90-031454d1f1ac","cf_app_name":"myappname","cf_space_id":"5c98b860-f5d2-444c-b923-XXXXX","cf_space_name":"myspacename","cf_org_id":"8005f45b-76d9-4038-8ca1-YYYYY","cf_org_name":"myorgname"}'
+EOD
 
 describe LogStash::Filters::Grok do
+ 
+  #Replace referenced cf-app-space-org-dictionary.yml path with path to test dictionary
+  test_dictionary = Tempfile.new('TEST-cf-app-space-org-dictionary.yml')
+  test_dictionary.write(DICTIONARY)
+  test_dictionary.close
+
+  filters_path = "target/logstash-filters-default.conf"
+  filters = File.read(filters_path) 
+  updated_filters = filters.gsub!("/var/vcap/store/cf_app_details_cache/cf_app_space_org_dictionary.yml", test_dictionary.path)
+  File.open("#{filters_path}-with-test-dictionary", "w") { |file| file << updated_filters }
 
   config <<-CONFIG
     filter {
       #{File.read("vendor/logsearch-boshrelease/logstash-filters-default.conf")} # This simulates the default parsing that logsearch v19+ does
-      #{File.read("target/logstash-filters-default.conf")}
+      #{File.read("target/logstash-filters-default.conf-with-test-dictionary")}
     }
   CONFIG
 
@@ -149,3 +169,4 @@ describe LogStash::Filters::Grok do
   end
 
 end
+

--- a/test/logstash-filters/snippets/doppler-spec.rb
+++ b/test/logstash-filters/snippets/doppler-spec.rb
@@ -130,7 +130,21 @@ describe LogStash::Filters::Grok do
       end
       
     end
-    
+   
+    describe "Decorate app logs with name, org and space" do
+      sample("@type" => "syslog", "@message" => '<6>2015-03-17T01:22:43Z jumpbox.xxxxxxx.com doppler[6375]: {"cf_app_id":"ec2d33f6-fd1c-49a5-9a90-031454d1f1ac","level":"info","message_type":"ERR","msg":"184.169.44.78, 192.168.16.3, 184.169.44.78, 10.10.0.71 - - [17/Mar/2015 01:21:42] \"GET / HTTP/1.1\" 200 5087 0.0022","source_instance":"0","source_type":"App","time":"2015-03-17T01:22:43Z"}') do
+
+        insist { subject["tags"] } == [ 'syslog_standard', 'cloudfoundry_doppler' ]
+        insist { subject["@type"] } == "cloudfoundry_doppler"
+
+        insist { subject["cf_app_id"] } == "ec2d33f6-fd1c-49a5-9a90-031454d1f1ac"
+
+        insist { subject["cf_app_name"] } == "myappname"
+        insist { subject["cf_space_name"] } == "myspace"
+        insist { subject["cf_org_name"] } == "myorg"
+      end
+      
+    end 
   end
 
 end

--- a/test/logstash-filters/snippets/doppler-spec.rb
+++ b/test/logstash-filters/snippets/doppler-spec.rb
@@ -133,6 +133,7 @@ describe LogStash::Filters::Grok do
    
     describe "Decorate app logs with name, org and space" do
       sample("@type" => "syslog", "@message" => '<6>2015-03-17T01:22:43Z jumpbox.xxxxxxx.com doppler[6375]: {"cf_app_id":"ec2d33f6-fd1c-49a5-9a90-031454d1f1ac","level":"info","message_type":"ERR","msg":"184.169.44.78, 192.168.16.3, 184.169.44.78, 10.10.0.71 - - [17/Mar/2015 01:21:42] \"GET / HTTP/1.1\" 200 5087 0.0022","source_instance":"0","source_type":"App","time":"2015-03-17T01:22:43Z"}') do
+        #puts subject.to_hash.to_yaml
 
         insist { subject["tags"] } == [ 'syslog_standard', 'cloudfoundry_doppler' ]
         insist { subject["@type"] } == "cloudfoundry_doppler"
@@ -140,8 +141,8 @@ describe LogStash::Filters::Grok do
         insist { subject["cf_app_id"] } == "ec2d33f6-fd1c-49a5-9a90-031454d1f1ac"
 
         insist { subject["cf_app_name"] } == "myappname"
-        insist { subject["cf_space_name"] } == "myspace"
-        insist { subject["cf_org_name"] } == "myorg"
+        insist { subject["cf_space_name"] } == "myspacename"
+        insist { subject["cf_org_name"] } == "myorgname"
       end
       
     end 

--- a/test/logstash-filters/snippets/loggregator-spec.rb
+++ b/test/logstash-filters/snippets/loggregator-spec.rb
@@ -7,7 +7,7 @@ describe LogStash::Filters::Grok do
   config <<-CONFIG
     filter {
       #{File.read("vendor/logsearch-boshrelease/logstash-filters-default.conf")} # This simulates the default parsing that logsearch v19+ does
-      #{File.read("target/logstash-filters-default.conf")}
+      #{File.read("src/logstash-filters/snippets/loggregator.conf")}
     }
   CONFIG
 

--- a/test/logstash-filters/snippets/vcap-spec.rb
+++ b/test/logstash-filters/snippets/vcap-spec.rb
@@ -10,7 +10,7 @@ describe LogStash::Filters::Grok do
   config <<-CONFIG
     filter {
       #{File.read("vendor/logsearch-boshrelease/logstash-filters-default.conf")} # This simulates the default parsing that logsearch v19+ does
-      #{File.read("target/logstash-filters-default.conf")}
+      #{File.read("src/logstash-filters/snippets/vcap.conf")}
     }
   CONFIG
 


### PR DESCRIPTION
Doppler tags all logs with a unique `cf_app_id` UUID, eg:

```
{"cf_app_id":"afc7d161-b5d5-44f2-a2c8-63870ff8f2db","level":"info","message_type":"OUT","msg":"goexample.apps.54.183.203.97.xip.io - [01/04/2015:10:22:50 +0000] \"GET / HTTP/1.1\" 200 7 \"-\" \"Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)\" 10.10.2.6:60637 x_forwarded_for:\"46.165.195.139, 10.10.2.6\" vcap_request_id:9f598459-f756-4ea4-58e5-e9f212ff328f response_time:0.002463550 app_id:afc7d161-b5d5-44f2-a2c8-63870ff8f2db\n","source_instance":"0","source_type":"RTR","time":"2015-04-01T10:22:50Z"}
```

UUIDs make for crappy dashboards:

![screen shot 2015-04-01 at 10 51 51](https://cloud.githubusercontent.com/assets/227505/6939213/36859e20-d862-11e4-977e-a03d3d58259b.png)

We should be decorating each log with:
* `cf_app_name`
* `cf_space_id` and `cf_space_name`
* `cf_org_id` and `cf_org_name`

so we can make human readable dashboards that can be segregated by app/space/org name.