### PR TITLE
Add multi-tenancy via cf-app-logs Kibana proxy

### DIFF
--- a/src/cf-app-logs/.gitignore
+++ b/src/cf-app-logs/.gitignore
@@ -1,0 +1,14 @@
+*~
+#*
+*#
+.#*
+.classpath
+.project
+.settings/
+.springBeans
+target/
+bin/
+_site/
+.idea
+*.iml
+.factorypath

--- a/src/cf-app-logs/manifest.yml
+++ b/src/cf-app-logs/manifest.yml
@@ -1,0 +1,17 @@
+---
+applications:
+- name: app-logs
+  memory: 512M
+  instances: 1
+  path: target/cf-app-logs-0.0.2-SNAPSHOT.jar
+  stack: cflinuxfs2
+  env:
+    spring_oauth2_client_clientId: logsearch_for_cloudfoundry
+    spring_oauth2_client_clientSecret: "XXXXXX"
+    spring_oauth2_client_accessTokenUri: http://login.run.54.183.203.97.xip.io/oauth/token
+    spring_oauth2_client_userAuthorizationUri: http://login.run.54.183.203.97.xip.io/oauth/authorize
+    spring_oauth2_resource_jwt_keyUri: http://uaa.run.54.183.203.97.xip.io/token_key
+    logsearch_elasticsearchAdminUri: http://10.10.5.6:9200
+    zuul_routes_kibana_url: http://logs.54.183.203.97.xip.io
+    cloudfoundry_cloudControllerUri: http://api.run.54.183.203.97.xip.io
+    cloudfoundry_uaaUri: http://uaa.run.54.183.203.97.xip.io

--- a/src/cf-app-logs/pom.xml
+++ b/src/cf-app-logs/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>io.logsearch</groupId>
+	<artifactId>cf-app-logs</artifactId>
+	<version>0.0.2-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>cf-app-logs</name>
+	<description>An OAuth2 authenticated proxy for Kibana4, that rewrites ES queries to only show data related to the authenticated user</description>
+
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-starter-parent</artifactId>
+		<version>1.0.1.BUILD-SNAPSHOT</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.cloudfoundry</groupId>
+			<artifactId>cloudfoundry-client-lib</artifactId>
+			<version>1.1.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-oauth2</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-zuul</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+        <groupId>org.springframework</groupId>
+	        <artifactId>spring-web</artifactId>
+	    </dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+		</dependency>
+		<dependency>
+		  <groupId>io.searchbox</groupId>
+		  <artifactId>jest</artifactId>
+		  <version>0.1.5</version>
+		</dependency>
+	</dependencies>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<java.version>1.7</java.version>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<!--skip deploy (this is just a test module) -->
+				<artifactId>maven-deploy-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<repositories>
+		<repository>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>http://repo.spring.io/libs-snapshot-local</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>http://repo.spring.io/libs-milestone-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>spring-releases</id>
+			<name>Spring Releases</name>
+			<url>http://repo.spring.io/libs-release-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>http://repo.spring.io/libs-snapshot-local</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>http://repo.spring.io/libs-milestone-local</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/src/cf-app-logs/src/main/java/logsearchForCloudFoundry/ElasticSearchRequestAddTenantFilterZuulFilter.java
+++ b/src/cf-app-logs/src/main/java/logsearchForCloudFoundry/ElasticSearchRequestAddTenantFilterZuulFilter.java
@@ -1,0 +1,131 @@
+package logsearchForCloudFoundry;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.Charset;
+
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.log4j.Logger;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+
+import com.netflix.zuul.ZuulFilter;
+import com.netflix.zuul.context.RequestContext;
+import com.netflix.zuul.http.HttpServletRequestWrapper;
+import com.netflix.zuul.http.ServletInputStreamWrapper;
+
+public class ElasticSearchRequestAddTenantFilterZuulFilter extends ZuulFilter {
+
+	private Field requestField;
+	private TenantAliasCreator tenantAliasCreator;
+	static Logger log = Logger.getLogger(ElasticSearchRequestAddTenantFilterZuulFilter.class.getName());
+	
+	public ElasticSearchRequestAddTenantFilterZuulFilter(TenantAliasCreator tenantAliasCreator) {
+		this.tenantAliasCreator = tenantAliasCreator;
+		this.requestField = ReflectionUtils.findField(HttpServletRequestWrapper.class,
+				"req", HttpServletRequest.class);
+		Assert.notNull(this.requestField, "HttpServletRequestWrapper.req field not found");
+		this.requestField.setAccessible(true);
+	}
+
+	@Override
+	public String filterType() {
+		return "pre";
+	}
+
+	@Override
+	public int filterOrder() {
+		return -1;
+	}
+
+	@Override
+	public boolean shouldFilter() {
+		RequestContext ctx = RequestContext.getCurrentContext();
+		HttpServletRequest request = ctx.getRequest();
+		
+		if (request.getRequestURI().startsWith("/elasticsearch")) {
+			log.debug("Filtering request:" + request.getRequestURI());
+			return true;
+		}
+		
+		return false;
+	}
+
+	@Override
+	public Object run() {
+		RequestContext ctx = RequestContext.getCurrentContext();
+		HttpServletRequest request = ctx.getRequest();
+
+		ElasticSearchRequestTenantFilterRequestWrapper wrapper = null;
+		if (request instanceof HttpServletRequestWrapper) {
+			HttpServletRequest wrapped = (HttpServletRequest) ReflectionUtils.getField(
+					this.requestField, request);
+			wrapper = new ElasticSearchRequestTenantFilterRequestWrapper(wrapped, tenantAliasCreator);
+			ReflectionUtils.setField(this.requestField, request, wrapper);
+		}
+		else {
+			wrapper = new ElasticSearchRequestTenantFilterRequestWrapper(request, tenantAliasCreator);
+			ctx.setRequest(wrapper);
+		}
+		return null;
+	}
+
+	private class ElasticSearchRequestTenantFilterRequestWrapper extends HttpServletRequestWrapper {
+
+		private HttpServletRequest request;
+
+		private byte[] contentData;
+
+		private int contentLength;
+
+		private ElasticsearchQueryModifier esQueryModifier;
+
+		public ElasticSearchRequestTenantFilterRequestWrapper(HttpServletRequest request, TenantAliasCreator tenantAliasCreator) {
+			super(request);
+			this.request = request;
+			this.esQueryModifier = new ElasticsearchQueryModifier(tenantAliasCreator);
+		}
+
+		@Override
+		public int getContentLength() {
+			if (super.getContentLength() <= 0) {
+				return super.getContentLength();
+			}
+			if (this.contentData == null) {
+				buildContentData();
+			}
+			return this.contentLength;
+		}
+
+		@Override
+		public ServletInputStream getInputStream() throws IOException {
+			if (this.contentData == null) {
+				buildContentData();
+			}
+			return new ServletInputStreamWrapper(this.contentData);
+		}
+
+		private synchronized void buildContentData() {
+			try {
+				StringBuffer jb = new StringBuffer();
+				String line = null;
+	
+			    BufferedReader reader = request.getReader();
+				while ((line = reader.readLine()) != null) {
+				  jb.append(line + "\n");
+				}
+				String modifiedQuery = esQueryModifier.ReplaceIndicesWithTenantAliases(jb.toString());
+				this.contentData = modifiedQuery.getBytes(Charset.forName("UTF-8"));
+				this.contentLength = this.contentData.length;
+			}
+			catch (Exception e) {
+				throw new IllegalStateException("Failed to rewrite ES query to use tenant specific aliases", e);
+			}
+		}
+
+	}
+
+}

--- a/src/cf-app-logs/src/main/java/logsearchForCloudFoundry/ElasticsearchQueryModifier.java
+++ b/src/cf-app-logs/src/main/java/logsearchForCloudFoundry/ElasticsearchQueryModifier.java
@@ -1,0 +1,30 @@
+package logsearchForCloudFoundry;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ElasticsearchQueryModifier {
+
+	private TenantAliasCreator tenantAliasCreator;
+
+	public ElasticsearchQueryModifier(TenantAliasCreator tenantAliasCreator) {
+		this.tenantAliasCreator = tenantAliasCreator;
+	}
+
+	public String ReplaceIndicesWithTenantAliases(String originalQuery) {
+		Pattern pattern = Pattern.compile("\"index\":\"(logstash-.*?)\"");
+        Matcher matcher = pattern.matcher(originalQuery);
+
+        StringBuffer modifiedQuery = new StringBuffer(originalQuery.length());
+
+        while(matcher.find())
+        {
+        	String indexName = matcher.group(1);
+        	matcher.appendReplacement(modifiedQuery, "\"index\":\"" + Matcher.quoteReplacement(tenantAliasCreator.fetchTenantAlias(indexName)) + "\"");
+        }
+        
+        matcher.appendTail(modifiedQuery);
+		return modifiedQuery.toString();
+	}
+
+}

--- a/src/cf-app-logs/src/main/java/logsearchForCloudFoundry/LogsearchForCloudFoundry.java
+++ b/src/cf-app-logs/src/main/java/logsearchForCloudFoundry/LogsearchForCloudFoundry.java
@@ -1,0 +1,55 @@
+package logsearchForCloudFoundry;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
+import org.springframework.cloud.security.oauth2.sso.EnableOAuth2Sso;
+import org.springframework.cloud.security.oauth2.sso.OAuth2SsoConfigurerAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Configuration
+@ComponentScan
+@EnableAutoConfiguration
+@RestController
+@RequestMapping("/")
+@EnableOAuth2Sso
+@EnableZuulProxy
+public class LogsearchForCloudFoundry {
+
+	@Autowired
+	private TenantAliasCreator tenantAliasCreator;
+	
+	@Bean
+	public ElasticSearchRequestAddTenantFilterZuulFilter myFilter() {
+	    return new ElasticSearchRequestAddTenantFilterZuulFilter(tenantAliasCreator);
+	}
+	
+	public static void main(String[] args) {
+		SpringApplication.run(LogsearchForCloudFoundry.class, args);
+	}
+	
+	 @Component
+	 public static class LoginConfigurer extends OAuth2SsoConfigurerAdapter {
+
+	 	@Override
+	 	public void configure(HttpSecurity http) throws Exception {
+	 		// Disable CSRF protection (leave that up to the backend we're proxying to, eg Kibana and/or Elasticsearch)
+	        http.csrf().disable();
+	        
+	 		http.antMatcher("/**")
+	 			.authorizeRequests()
+	 			.anyRequest()
+	 			.authenticated();
+	 	}
+
+	 }
+}
+ 

--- a/src/cf-app-logs/src/main/java/logsearchForCloudFoundry/SimpleUAAClient.java
+++ b/src/cf-app-logs/src/main/java/logsearchForCloudFoundry/SimpleUAAClient.java
@@ -1,0 +1,29 @@
+package logsearchForCloudFoundry;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.security.oauth2.client.OAuth2RestOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope(value="session", proxyMode=ScopedProxyMode.TARGET_CLASS)
+public class SimpleUAAClient {
+	
+	@Autowired
+	private OAuth2RestOperations restTemplate;
+	private UserInfo userInfo = null;	
+	
+	@Value("${cloudfoundry.uaaUri}")
+    private String uaaUri;
+	
+	public UserInfo getUserInfo() {
+		if (userInfo == null) {
+			userInfo  = restTemplate.getForObject(uaaUri+"/userinfo", UserInfo.class);
+		}
+		return userInfo ;
+	}
+
+
+}

--- a/src/cf-app-logs/src/main/java/logsearchForCloudFoundry/TenantAliasCreator.java
+++ b/src/cf-app-logs/src/main/java/logsearchForCloudFoundry/TenantAliasCreator.java
@@ -1,0 +1,176 @@
+package logsearchForCloudFoundry;
+
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestClientFactory;
+import io.searchbox.client.JestResult;
+import io.searchbox.client.config.HttpClientConfig;
+import io.searchbox.cluster.State;
+import io.searchbox.indices.aliases.AddAliasMapping;
+import io.searchbox.indices.aliases.AliasMapping;
+import io.searchbox.indices.aliases.ModifyAliases;
+import io.searchbox.indices.aliases.RemoveAliasMapping;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.log4j.Logger;
+import org.cloudfoundry.client.lib.CloudCredentials;
+import org.cloudfoundry.client.lib.CloudFoundryClient;
+import org.cloudfoundry.client.lib.domain.CloudSpace;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.security.oauth2.client.OAuth2ClientContext;
+import org.springframework.stereotype.Component;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+@Component
+@Scope(value="session", proxyMode=ScopedProxyMode.TARGET_CLASS)
+public class TenantAliasCreator {
+	@Autowired
+	private OAuth2ClientContext oauth2Context;
+	
+	@Autowired
+	private SimpleUAAClient uaaClient = null;
+	
+	@Value("${cloudfoundry.cloudControllerUri}")
+    private String cloudControllerUri;
+	
+	@Value("${logsearch.elasticsearchAdminUri}")
+    private String elasticsearchAdminUri;
+	
+	static Logger log = Logger.getLogger(TenantAliasCreator.class.getName());
+	private CloudFoundryClient cloudFoundryClient = null;
+	private JestClient jestClient = null;
+	private Map<UUID, String> authorizedSpaces = new HashMap<UUID, String> ();
+	private Map<String, String> tenantIndexAliases = new HashMap<String, String> ();
+
+	private String tenantUsername;
+	
+	private URL getCloudControllerUrl() {
+		URL cloudControllerUrl = null;
+		try {
+			cloudControllerUrl = new URL(cloudControllerUri);
+		} catch (MalformedURLException e) {
+			log.error(e);
+			e.printStackTrace();
+		}
+		return cloudControllerUrl;
+	}
+
+	public String fetchTenantAlias(String originalIndexName) {
+		setupTenantAliases();
+		if (tenantIndexAliases.containsKey(originalIndexName)) {
+			return tenantIndexAliases.get(originalIndexName);
+		}
+		return tenantUsername + "-" + originalIndexName;
+	}
+	
+	private void setupTenantAliases() {	
+		if (!tenantIndexAliases.isEmpty())
+			return; //Only setup Tenant Aliases once / session
+		
+		tenantUsername = uaaClient.getUserInfo().getUserName();
+		
+		log.debug("Setting up tenant aliases for: " + tenantUsername);
+		
+		tenantIndexAliases.put(".kibana", ".kibana"); //Shared kibana index
+		
+		Map<String, Object> authorisedSpaceFilter = createAuthorisedSpacesFilter();
+		ArrayList<String> indexNames = getIndexNames();
+		
+		ArrayList<AliasMapping> removeAliasActions = new ArrayList<AliasMapping>();
+		ArrayList<AliasMapping> addAliasActions = new ArrayList<AliasMapping>();
+		for (String indexName : indexNames) {
+			if (indexName.contains("logstash-")) {
+				String aliasName = tenantUsername + "-" + indexName;
+				
+				log.debug("Adding alias: " + aliasName + " for index: " + indexName);
+				
+				removeAliasActions.add(new RemoveAliasMapping.Builder(indexName, aliasName).build());
+				addAliasActions.add(new AddAliasMapping.Builder(indexName, aliasName).setFilter(authorisedSpaceFilter).build());
+				tenantIndexAliases.put(indexName, aliasName);
+			}
+		}
+		ModifyAliases modifyAliases = new ModifyAliases.Builder(removeAliasActions).addAlias(addAliasActions).build();
+
+		try {
+			log.debug("Sending alias commands to ES: " + modifyAliases.toString());
+			JestResult result = getJestClient().execute(modifyAliases);
+	        if (!result.isSucceeded()) {
+	        	throw new Exception(result.getErrorMessage());
+	        }
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			log.error(e);
+			e.printStackTrace();
+		}
+        
+	}
+
+	private ArrayList<String> getIndexNames() {
+		ArrayList<String> indexNames = new ArrayList<String>();
+		try {
+			JestResult result = getJestClient().execute(new State.Builder().build());
+			JsonObject indiciesJson = result.getJsonObject().getAsJsonObject("metadata").getAsJsonObject("indices");
+			for (Entry<String, JsonElement> index : indiciesJson.entrySet()) {
+				indexNames.add(index.getKey());
+			}
+		} catch (Exception e1) {
+			log.error(e1);
+			e1.printStackTrace();
+		}
+		return indexNames;
+	}
+
+	private Map<String, Object> createAuthorisedSpacesFilter() {
+		fetchAuthorisedSpaces();
+		Map<String, Object> authorizedSpaceFilter = ImmutableMap.<String, Object>builder()
+	            .put("terms", ImmutableMap.<String, Set<UUID>>builder()
+	                    .put("cf_space_id", authorizedSpaces.keySet())
+	                    .build())
+	            .build();
+		return authorizedSpaceFilter;
+	}
+	
+	private void fetchAuthorisedSpaces() {
+		if (!authorizedSpaces.isEmpty())
+			return; //Only lookup spaces once / session
+		
+		for (CloudSpace space : getCloudFoundryClient().getSpaces()) {
+				authorizedSpaces.put(space.getMeta().getGuid(), space.getName());
+		}
+	}
+	
+	private JestClient getJestClient() {
+		 if (this.jestClient == null) {
+			 JestClientFactory factory = new JestClientFactory();
+			 factory.setHttpClientConfig(new HttpClientConfig
+			                        .Builder(elasticsearchAdminUri)
+			                        .multiThreaded(true)
+			                        .build());
+			 this.jestClient = factory.getObject();
+		 }
+		 return this.jestClient;
+	}
+
+	private CloudFoundryClient getCloudFoundryClient() {
+		if (this.cloudFoundryClient == null) {
+			CloudCredentials credentials = new CloudCredentials(oauth2Context.getAccessToken());
+			this.cloudFoundryClient = new CloudFoundryClient(credentials, getCloudControllerUrl());
+		}
+		return this.cloudFoundryClient;
+	}
+	
+}
+

--- a/src/cf-app-logs/src/main/java/logsearchForCloudFoundry/UserInfo.java
+++ b/src/cf-app-logs/src/main/java/logsearchForCloudFoundry/UserInfo.java
@@ -1,0 +1,30 @@
+package logsearchForCloudFoundry;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserInfo {
+
+	@JsonProperty("user_id")
+	protected String user_id;
+    @JsonProperty("user_name")
+	protected String user_name;
+    @JsonProperty("email")
+	protected String email;
+   
+    public UUID getUserId() {
+        return UUID.fromString(this.user_id);
+    }
+
+    public String getUserName() {
+        return this.user_name;
+    }
+
+    public String getEmail() {
+        return this.email;
+    }
+
+}

--- a/src/cf-app-logs/src/main/resources/application.yml
+++ b/src/cf-app-logs/src/main/resources/application.yml
@@ -1,0 +1,47 @@
+debug:
+server:
+  port: 9999
+
+security:
+  sessions: ALWAYS
+  user:
+    password: user
+# ignored: /favicon.ico,/index.html,/home.html,/dashboard.html,/js/**,/css/**,/webjars/**
+# management:
+#   security:
+#     role: HERO
+
+logging:
+  level:
+    org.springframework.security: DEBUG
+    com.netflix.discovery: 'OFF'
+
+zuul:
+  routes:
+    kibana:
+      path: /**
+      url: http://logs.54.183.203.97.xip.io
+
+cloudfoundry:
+  cloudControllerUri: http://api.run.54.183.203.97.xip.io
+  uaaUri: http://uaa.run.54.183.203.97.xip.io
+
+logsearch:
+  elasticsearchAdminUri: http://127.0.0.1:9200
+
+spring:
+  oauth2:
+    sso:
+      loginPath: /login
+      logoutPath: /logout
+    client:
+      accessTokenUri: http://login.run.54.183.203.97.xip.io/oauth/token
+      userAuthorizationUri: http://login.run.54.183.203.97.xip.io/oauth/authorize
+      clientId: logsearch_for_cloudfoundry-dev
+      clientSecret: "XXXXXXX"
+      scope: "openid,scim.userids,cloud_controller.read"
+    resource:
+      jwt:
+        keyUri: http://uaa.run.54.183.203.97.xip.io/token_key
+      id: openid
+      serviceId: ${PREFIX:}resource

--- a/src/cf-app-logs/src/test/java/logsearchForCloudFoundry/ElasticsearchQueryModifierTests.java
+++ b/src/cf-app-logs/src/test/java/logsearchForCloudFoundry/ElasticsearchQueryModifierTests.java
@@ -1,0 +1,89 @@
+package logsearchForCloudFoundry;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+public class ElasticsearchQueryModifierTests {
+
+	@Test
+	public void shouldReplaceSingleIndexInMQuery() {
+		TenantAliasCreator mockTenantAliasCreator = mock(TenantAliasCreator.class);
+		when(mockTenantAliasCreator.fetchTenantAlias("logstash-*")).thenReturn("tenantName-logstash-*");
+		
+		ElasticsearchQueryModifier m = new ElasticsearchQueryModifier(mockTenantAliasCreator);
+		String originalQuery = "{\"index\":\"logstash-*\",\"ignore_unavailable\":true}\n" + 
+				"{\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}}},\"query\":{\"filtered\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":{\"bool\":{\"must\":[{\"query\":{\"match\":{\"@type\":{\"query\":\"cloudfoundry_doppler\",\"type\":\"phrase\"}}}},{\"query\":{\"match\":{\"event_type\":{\"query\":\"LogMessage\",\"type\":\"phrase\"}}}},{\"query\":{\"match\":{\"source_type\":{\"query\":\"RTR\",\"type\":\"phrase\"}}}},{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},{\"range\":{\"@timestamp\":{\"gte\":1428682141572,\"lte\":1428683041572}}}],\"must_not\":[]}}}},\"size\":500,\"sort\":{\"@timestamp\":\"desc\"},\"fields\":[\"*\",\"_source\"],\"script_fields\":{},\"fielddata_fields\":[\"@timestamp\",\"received_at\"]}\n";
+		String modifiedQuery = m.ReplaceIndicesWithTenantAliases(originalQuery);
+		
+		assertEquals(originalQuery.replace("logstash-*", "tenantName-logstash-*"), modifiedQuery);
+	}
+	
+	@Test
+	public void shouldReplaceIndiciesInMQuery() {
+		TenantAliasCreator mockTenantAliasCreator = mock(TenantAliasCreator.class);
+		when(mockTenantAliasCreator.fetchTenantAlias("logstash-*")).thenReturn("tenantName-logstash-*");
+		
+		ElasticsearchQueryModifier m = new ElasticsearchQueryModifier(mockTenantAliasCreator);
+		String originalQuery = "{\"index\":\"logstash-*\",\"ignore_unavailable\":true}\n" + 
+				"{\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}}},\"query\":{\"filtered\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":{\"bool\":{\"must\":[{\"query\":{\"match\":{\"@type\":{\"query\":\"cloudfoundry_doppler\",\"type\":\"phrase\"}}}},{\"query\":{\"match\":{\"event_type\":{\"query\":\"LogMessage\",\"type\":\"phrase\"}}}},{\"query\":{\"match\":{\"source_type\":{\"query\":\"RTR\",\"type\":\"phrase\"}}}},{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},{\"range\":{\"@timestamp\":{\"gte\":1428682141572,\"lte\":1428683041572}}}],\"must_not\":[]}}}},\"size\":500,\"sort\":{\"@timestamp\":\"desc\"},\"fields\":[\"*\",\"_source\"],\"script_fields\":{},\"fielddata_fields\":[\"@timestamp\",\"received_at\"]}\n" + 
+				"{\"index\":\"logstash-*\",\"search_type\":\"count\",\"ignore_unavailable\":true}\n" + 
+				"{\"size\":0,\"aggs\":{\"3\":{\"terms\":{\"field\":\"cf_app_name\",\"size\":25,\"order\":{\"_count\":\"desc\"}},\"aggs\":{\"2\":{\"date_histogram\":{\"field\":\"@timestamp\",\"interval\":\"30s\",\"pre_zone\":\"+01:00\",\"pre_zone_adjust_large_interval\":true,\"min_doc_count\":1,\"extended_bounds\":{\"min\":1428682141570,\"max\":1428683041570}},\"aggs\":{\"4\":{\"terms\":{\"field\":\"verb\",\"size\":5,\"order\":{\"_count\":\"desc\"}}}}}}}},\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}}},\"query\":{\"filtered\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":{\"bool\":{\"must\":[{\"query\":{\"match\":{\"@type\":{\"query\":\"cloudfoundry_doppler\",\"type\":\"phrase\"}}}},{\"query\":{\"match\":{\"event_type\":{\"query\":\"LogMessage\",\"type\":\"phrase\"}}}},{\"query\":{\"match\":{\"source_type\":{\"query\":\"RTR\",\"type\":\"phrase\"}}}},{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},{\"range\":{\"@timestamp\":{\"gte\":1428682141572,\"lte\":1428683041572}}}],\"must_not\":[]}}}}}\n" + 
+				"{\"index\":\"logstash-*\",\"search_type\":\"count\",\"ignore_unavailable\":true}\n" + 
+				"{\"size\":0,\"aggs\":{\"2\":{\"terms\":{\"field\":\"cf_app_name\",\"size\":25,\"order\":{\"_count\":\"desc\"}}}},\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}}},\"query\":{\"filtered\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":{\"bool\":{\"must\":[{\"query\":{\"match\":{\"@type\":{\"query\":\"cloudfoundry_doppler\",\"type\":\"phrase\"}}}},{\"query\":{\"match\":{\"event_type\":{\"query\":\"LogMessage\",\"type\":\"phrase\"}}}},{\"query\":{\"match\":{\"source_type\":{\"query\":\"RTR\",\"type\":\"phrase\"}}}},{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},{\"range\":{\"@timestamp\":{\"gte\":1428682141572,\"lte\":1428683041572}}}],\"must_not\":[]}}}}}\n" + 
+				"{\"index\":\"logstash-*\",\"search_type\":\"count\",\"ignore_unavailable\":true}\n" + 
+				"{\"size\":0,\"aggs\":{\"2\":{\"terms\":{\"field\":\"status\",\"size\":10,\"order\":{\"_count\":\"desc\"}}}},\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}}},\"query\":{\"filtered\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":{\"bool\":{\"must\":[{\"query\":{\"match\":{\"@type\":{\"query\":\"cloudfoundry_doppler\",\"type\":\"phrase\"}}}},{\"query\":{\"match\":{\"event_type\":{\"query\":\"LogMessage\",\"type\":\"phrase\"}}}},{\"query\":{\"match\":{\"source_type\":{\"query\":\"RTR\",\"type\":\"phrase\"}}}},{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},{\"range\":{\"@timestamp\":{\"gte\":1428682141572,\"lte\":1428683041572}}}],\"must_not\":[]}}}}}\n" + 
+				"{\"index\":\"logstash-*\",\"search_type\":\"count\",\"ignore_unavailable\":true}\n" + 
+				"{\"size\":0,\"aggs\":{\"2\":{\"terms\":{\"field\":\"http_user_agent\",\"size\":25,\"order\":{\"_count\":\"desc\"}}}},\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}}},\"query\":{\"filtered\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":{\"bool\":{\"must\":[{\"query\":{\"match\":{\"@type\":{\"query\":\"cloudfoundry_doppler\",\"type\":\"phrase\"}}}},{\"query\":{\"match\":{\"event_type\":{\"query\":\"LogMessage\",\"type\":\"phrase\"}}}},{\"query\":{\"match\":{\"source_type\":{\"query\":\"RTR\",\"type\":\"phrase\"}}}},{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},{\"range\":{\"@timestamp\":{\"gte\":1428682141572,\"lte\":1428683041573}}}],\"must_not\":[]}}}}}\n" + 
+				"{\"index\":\"logstash-*\",\"search_type\":\"count\",\"ignore_unavailable\":true}\n" + 
+				"{\"size\":0,\"aggs\":{\"2\":{\"terms\":{\"field\":\"geoip.ip\",\"size\":25,\"order\":{\"_count\":\"desc\"}}}},\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}}},\"query\":{\"filtered\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":{\"bool\":{\"must\":[{\"query\":{\"match\":{\"@type\":{\"query\":\"cloudfoundry_doppler\",\"type\":\"phrase\"}}}},{\"query\":{\"match\":{\"event_type\":{\"query\":\"LogMessage\",\"type\":\"phrase\"}}}},{\"query\":{\"match\":{\"source_type\":{\"query\":\"RTR\",\"type\":\"phrase\"}}}},{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},{\"range\":{\"@timestamp\":{\"gte\":1428682141573,\"lte\":1428683041573}}}],\"must_not\":[]}}}}}\n" + 
+				"{\"index\":\"logstash-*\",\"search_type\":\"count\",\"ignore_unavailable\":true}\n" + 
+				"{\"size\":0,\"aggs\":{\"3\":{\"terms\":{\"field\":\"cf_app_name\",\"size\":25,\"order\":{\"1.50\":\"desc\"}},\"aggs\":{\"1\":{\"percentiles\":{\"field\":\"response_time\",\"percents\":[50,95]}},\"2\":{\"date_histogram\":{\"field\":\"@timestamp\",\"interval\":\"30s\",\"pre_zone\":\"+01:00\",\"pre_zone_adjust_large_interval\":true,\"min_doc_count\":1,\"extended_bounds\":{\"min\":1428682141572,\"max\":1428683041572}},\"aggs\":{\"1\":{\"percentiles\":{\"field\":\"response_time\",\"percents\":[50,95]}}}}}}},\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}}},\"query\":{\"filtered\":{\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":{\"bool\":{\"must\":[{\"query\":{\"match\":{\"@type\":{\"query\":\"cloudfoundry_doppler\",\"type\":\"phrase\"}}}},{\"query\":{\"match\":{\"event_type\":{\"query\":\"LogMessage\",\"type\":\"phrase\"}}}},{\"query\":{\"match\":{\"source_type\":{\"query\":\"RTR\",\"type\":\"phrase\"}}}},{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},{\"range\":{\"@timestamp\":{\"gte\":1428682141573,\"lte\":1428683041573}}}],\"must_not\":[]}}}}}";
+		String modifiedQuery = m.ReplaceIndicesWithTenantAliases(originalQuery);
+		
+		assertEquals(originalQuery.replace("logstash-*", "tenantName-logstash-*"), modifiedQuery);
+	}
+	
+	@Test
+	public void shouldReplaceMultipleDifferentIndiciesInMQuery() {
+		TenantAliasCreator mockTenantAliasCreator = mock(TenantAliasCreator.class);
+		when(mockTenantAliasCreator.fetchTenantAlias("logstash-2015.03.28")).thenReturn("tenantName-logstash-2015.03.28");
+		when(mockTenantAliasCreator.fetchTenantAlias("logstash-2015.03.29")).thenReturn("tenantName-logstash-2015.03.29");
+		
+		ElasticsearchQueryModifier m = new ElasticsearchQueryModifier(mockTenantAliasCreator);
+		String originalQuery = 
+				"{\"index\":\"logstash-2015.03.28\",\"ignore_unavailable\":true}\n" + 
+				"{\"size\":500,\"sort\":{\"@timestamp\":\"desc\"},\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}}},\"aggs\":{\"2\":{\"date_histogram\":{\"field\":\"@timestamp\",\"interval\":\"30s\",\"pre_zone\":\"+01:00\",\"pre_zone_adjust_large_interval\":true,\"min_doc_count\":0,\"extended_bounds\":{\"min\":1428678200944,\"max\":1428679100944}}}},\"query\":{\"filtered\":{\"query\":{\"match_all\":{}},\"filter\":{\"bool\":{\"must\":[{\"range\":{\"@timestamp\":{\"gte\":1428678200944,\"lte\":1428679100944}}}],\"must_not\":[]}}}},\"fields\":[\"*\",\"_source\"],\"script_fields\":{},\"fielddata_fields\":[\"@timestamp\",\"received_at\"]}" +
+				"{\"index\":\"logstash-2015.03.29\",\"ignore_unavailable\":true}\n" + 
+				"{\"size\":500,\"sort\":{\"@timestamp\":\"desc\"},\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}}},\"aggs\":{\"2\":{\"date_histogram\":{\"field\":\"@timestamp\",\"interval\":\"30s\",\"pre_zone\":\"+01:00\",\"pre_zone_adjust_large_interval\":true,\"min_doc_count\":0,\"extended_bounds\":{\"min\":1428678200944,\"max\":1428679100944}}}},\"query\":{\"filtered\":{\"query\":{\"match_all\":{}},\"filter\":{\"bool\":{\"must\":[{\"range\":{\"@timestamp\":{\"gte\":1428678200944,\"lte\":1428679100944}}}],\"must_not\":[]}}}},\"fields\":[\"*\",\"_source\"],\"script_fields\":{},\"fielddata_fields\":[\"@timestamp\",\"received_at\"]}";
+
+		String modifiedQuery = m.ReplaceIndicesWithTenantAliases(originalQuery);
+		
+		assertEquals(originalQuery
+						.replace("logstash-2015.03.28", "tenantName-logstash-2015.03.28")
+						.replace("logstash-2015.03.29", "tenantName-logstash-2015.03.29"), 
+					 modifiedQuery);
+	}
+	
+	@Test
+	public void shouldNotReplaceKibanaIndicies() {
+		TenantAliasCreator mockTenantAliasCreator = mock(TenantAliasCreator.class);
+		when(mockTenantAliasCreator.fetchTenantAlias(".kibana")).thenReturn(".kibana");
+		
+		ElasticsearchQueryModifier m = new ElasticsearchQueryModifier(mockTenantAliasCreator);
+		String originalQuery = "{\"docs\":[{\"_index\":\".kibana\",\"_type\":\"config\",\"_id\":\"4.0.1\"}]}";
+		String modifiedQuery = m.ReplaceIndicesWithTenantAliases(originalQuery);
+		
+		assertEquals(originalQuery, modifiedQuery);
+	}
+
+}
+
+/**
+{"docs":[{"_index":".kibana","_type":"config","_id":"4.0.1"}]}
+
+{"index":"logstash-*","ignore_unavailable":true}
+{"size":500,"sort":{"@timestamp":"desc"},"highlight":{"pre_tags":["@kibana-highlighted-field@"],"post_tags":["@/kibana-highlighted-field@"],"fields":{"*":{}}},"aggs":{"2":{"date_histogram":{"field":"@timestamp","interval":"30s","pre_zone":"+01:00","pre_zone_adjust_large_interval":true,"min_doc_count":0,"extended_bounds":{"min":1428678200944,"max":1428679100944}}}},"query":{"filtered":{"query":{"match_all":{}},"filter":{"bool":{"must":[{"range":{"@timestamp":{"gte":1428678200944,"lte":1428679100944}}}],"must_not":[]}}}},"fields":["*","_source"],"script_fields":{},"fielddata_fields":["@timestamp","received_at"]}
+*/


### PR DESCRIPTION
The PR implements a proxy for Kibana4 based on Spring Cloud's OAuth2 and Zuul modules.

It intercepts all Kibana4 requests, logs the user in via CF's UAA component, ensures that aliases for the user exist on all ES indices and contain appropriate space_id filters, and rewrites all ES requests so that the are made against the user's aliases rather than the underlying indices.

The effect is that all queries made by the user return only data for apps in spaces they are a member of.

The proxy is indented to be deployed as an app in the CF cluster