### PR TITLE
Fix: cloudfoundry.firehose_events not being merged by spiff

### DIFF
--- a/logsearch-for-cloudfoundry-boshrelease/templates/stub.yml
+++ b/logsearch-for-cloudfoundry-boshrelease/templates/stub.yml
@@ -29,6 +29,7 @@ properties:
     admin_client_secret: "admin-secret"
     firehose_user: admin
     firehose_password: admin
+    firehose_events: LogMessage,Error,ContainerMetric
   elasticsearch:
     admin_ip: "10.244.10.2"
     admin_port: 9200


### PR DESCRIPTION
Hello,

During my tests, the property cloudfoundry.firehose_events was not merged by spiff using make_manifest script.

I have added to stub.yml the default value for this property. With this, we can define this value in a sub-template...