### PR TITLE
Enable ingestor_cloudfoundry-firehose to be colocated with ingestors from core logsearch-boshrelease

### DIFF
--- a/logsearch-for-cloudfoundry-boshrelease/config/blobs.yml
+++ b/logsearch-for-cloudfoundry-boshrelease/config/blobs.yml
@@ -15,18 +15,10 @@ kibana-for-cf/kibana-4.1.0-snapshot-linux-x64.tar.gz:
   object_id: 0fa871c7-a7bd-4afe-8d83-11c262cb4041
   sha: 99949ff3c2e3486f62ff4f2998725b8863aac7ed
   size: 25238338
-java8/openjdk-1.8.0_40.tar.gz:
-  object_id: 0c1b6d9d-8d6a-4dc8-80fa-66f484fa08b1
-  sha: 590be5c6337753b28acc81d4843e98e6245b5261
-  size: 39630740
 kibana-for-cf/kibana-4.1.1-snapshot-linux-x86.tar.gz:
   object_id: 351cee49-f1d1-4268-9137-ee2786b3ac87
   sha: 467ac079fe81e8eeaf54cf4551b2be003f0572fe
   size: 10429710
-logstash/logstash-1.5.0.tar.gz:
-  object_id: cda507fe-7378-47b1-9b28-1ef4ae72ee58
-  sha: 9729c2d31fddaabdd3d8e94c34a6d1f61d57f94a
-  size: 87008665
 kibana-for-cf/kibana-4.2.0-snapshot-linux-x64-with-cf-authentication.tar.gz:
   object_id: 8e596ad6-5060-43b8-a6ed-a433fcf095be
   sha: 2bc5b5fa73e9775bfdb81d465508f29a7cf69c6e
@@ -35,3 +27,11 @@ kibana-for-cf/kibana-4.2.0-snapshot-linux-x64.tar.gz:
   object_id: aa5e83fb-f81b-4cb9-bb47-604766672044
   sha: 201e90d88142474db1fd2816ca15d79f147c9a3b
   size: 13453492
+firehose-to-syslog-logstash/logstash-1.5.2.tar.gz:
+  object_id: 0968e974-fe94-43d3-a78e-91d160d91de9
+  sha: 92e4ce646ca6a1868bac56def5ddf096349ec0a6
+  size: 91217160
+firehose-to-syslog-java8/openjdk-1.8.0_40.tar.gz:
+  object_id: 2a24f27d-3fab-4c38-970d-b454e8952f39
+  sha: 590be5c6337753b28acc81d4843e98e6245b5261
+  size: 39630740

--- a/logsearch-for-cloudfoundry-boshrelease/jobs/ingestor_cloudfoundry-firehose/spec
+++ b/logsearch-for-cloudfoundry-boshrelease/jobs/ingestor_cloudfoundry-firehose/spec
@@ -2,8 +2,8 @@
 name: ingestor_cloudfoundry-firehose
 packages:
 - firehose-to-syslog
-- logstash
-- java8
+- firehose-to-syslog-logstash
+- firehose-to-syslog-java8
 templates:
   bin/ingestor_cloudfoundry-firehose_ctl: bin/ingestor_cloudfoundry-firehose_ctl
   bin/monit_debugger: bin/monit_debugger

--- a/logsearch-for-cloudfoundry-boshrelease/jobs/ingestor_cloudfoundry-firehose/templates/bin/ingestor_cloudfoundry-firehose_ctl
+++ b/logsearch-for-cloudfoundry-boshrelease/jobs/ingestor_cloudfoundry-firehose/templates/bin/ingestor_cloudfoundry-firehose_ctl
@@ -9,6 +9,8 @@ source /var/vcap/jobs/ingestor_cloudfoundry-firehose/helpers/ctl_setup.sh 'inges
 export PORT=${PORT:-5000}
 export LANG=en_US.UTF-8
 
+export JAVA_HOME="/var/vcap/packages/firehose-to-syslog-java8"
+
 # 1 logstash worker / CPU core
 export LOGSTASH_WORKERS=`grep -c ^processor /proc/cpuinfo`
 

--- a/logsearch-for-cloudfoundry-boshrelease/jobs/ingestor_cloudfoundry-firehose/templates/bin/ingestor_cloudfoundry-firehose_ctl
+++ b/logsearch-for-cloudfoundry-boshrelease/jobs/ingestor_cloudfoundry-firehose/templates/bin/ingestor_cloudfoundry-firehose_ctl
@@ -22,7 +22,7 @@ case $1 in
     # store this processes pid in $PIDFILE, since the exec below doesn't daemonize
     echo $$ > $PIDFILE_syslog
 
-    exec /var/vcap/packages/logstash/logstash/bin/logstash agent \
+    exec /var/vcap/packages/firehose-to-syslog-logstash/logstash/bin/logstash agent \
          -f ${JOB_DIR}/config/syslog_to_redis.conf -w ${LOGSTASH_WORKERS} \
          >>$LOG_DIR/$JOB_NAME_syslog.stdout.log \
          2>>$LOG_DIR/$JOB_NAME_syslog.stderr.log

--- a/logsearch-for-cloudfoundry-boshrelease/packages/firehose-to-syslog-java8/packaging
+++ b/logsearch-for-cloudfoundry-boshrelease/packages/firehose-to-syslog-java8/packaging
@@ -6,7 +6,7 @@ set -u # report the usage of uninitialized variables
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 
 if [[ `uname -a` =~ "x86_64" ]] ; then
-  archive="java8/openjdk-1.8.0_40.tar.gz"
+  archive="firehose-to-syslog-java8/openjdk-1.8.0_40.tar.gz"
 else
   echo "Only 64-bit architectures are supported."
   exit 1

--- a/logsearch-for-cloudfoundry-boshrelease/packages/firehose-to-syslog-java8/spec
+++ b/logsearch-for-cloudfoundry-boshrelease/packages/firehose-to-syslog-java8/spec
@@ -1,0 +1,4 @@
+---
+name: firehose-to-syslog-java8
+files:
+- firehose-to-syslog-java8/openjdk-1.8.0_40.tar.gz

--- a/logsearch-for-cloudfoundry-boshrelease/packages/firehose-to-syslog-logstash/packaging
+++ b/logsearch-for-cloudfoundry-boshrelease/packages/firehose-to-syslog-logstash/packaging
@@ -6,4 +6,4 @@ set -u # report the usage of uninitialized variables
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 
 mkdir $BOSH_INSTALL_TARGET/logstash
-tar -xzf logstash/logstash-1.5.0.tar.gz -C $BOSH_INSTALL_TARGET/logstash --strip-components 1
+tar -xzf firehose-to-syslog-logstash/logstash-1.5.2.tar.gz -C $BOSH_INSTALL_TARGET/logstash --strip-components 1

--- a/logsearch-for-cloudfoundry-boshrelease/packages/firehose-to-syslog-logstash/spec
+++ b/logsearch-for-cloudfoundry-boshrelease/packages/firehose-to-syslog-logstash/spec
@@ -1,0 +1,6 @@
+---
+name: firehose-to-syslog-logstash
+dependencies: []
+files: 
+  # https://download.elastic.co/logstash/logstash/logstash-1.5.2.tar.gz
+  - firehose-to-syslog-logstash/logstash-1.5.2.tar.gz

--- a/logsearch-for-cloudfoundry-boshrelease/packages/java8/spec
+++ b/logsearch-for-cloudfoundry-boshrelease/packages/java8/spec
@@ -1,4 +1,0 @@
----
-name: java8
-files:
-- java8/openjdk-1.8.0_40.tar.gz

--- a/logsearch-for-cloudfoundry-boshrelease/packages/logstash/spec
+++ b/logsearch-for-cloudfoundry-boshrelease/packages/logstash/spec
@@ -1,6 +1,0 @@
----
-name: logstash
-dependencies: []
-files: 
-  # https://download.elastic.co/logstash/logstash/logstash-1.5.0.tar.gz
-  - logstash/logstash-1.5.0.tar.gz


### PR DESCRIPTION
Prevent naming conflicts with core `logsearch-boshrelease` by renaming 

* `packages/logstash` -> `packages/firehose-to-syslog-logstash`
* `packages/java8` -> `packages/firehose-to-syslog-java8`

Also updates `packages/firehose-to-syslog-logstash` from logstash 1.5.0 to logstash 1.5.2

This addresses #45 and #63 