### PR TITLE
Configure app memory & instances

### DIFF
--- a/logsearch-for-cloudfoundry-boshrelease/jobs/push-kibana/spec
+++ b/logsearch-for-cloudfoundry-boshrelease/jobs/push-kibana/spec
@@ -16,6 +16,12 @@ properties:
   push-kibana.kibana_index:
     description: "Elasticsearch index to store Kibana settings and dashboards"
     default: ".kibana"
+  push-kibana.app_memory:
+    description: "The Kibana log dashboard app memory quota"
+    default: 256M
+  push-kibana.app_instances:
+    description: "The Kibana log dashboard app number of instances"
+    default: 2
 
   push-kibana.oauth2_client_id:
     description: "The UAA kibana oauth2 client id"

--- a/logsearch-for-cloudfoundry-boshrelease/jobs/push-kibana/templates/config/manifest.yml
+++ b/logsearch-for-cloudfoundry-boshrelease/jobs/push-kibana/templates/config/manifest.yml
@@ -1,9 +1,9 @@
 ---
 applications:
 - name: <%= p('push-kibana.app_name')%>
+  memory: <%= p('push-kibana.app_memory')%>
+  instances: <%= p('push-kibana.app_instances')%>
   domain: <%= p('cloudfoundry.system_domain')%>
-  memory: 256M
-  instances: 2
   buildpack: nodejs_buildpack
   command: CONFIG_PATH=$HOME/kibana.yml exec node $HOME/bin/kibana.js --port $PORT
   env:


### PR DESCRIPTION
Enable configuring the CF memory and instances used by the Kibana dashboard.

```
push-kibana.app_memory:
   description: "The Kibana log dashboard app memory quota"
   default: 256M
push-kibana.app_instances:
   description: "The Kibana log dashboard app number of instances"
   default: 2
```